### PR TITLE
Add missing @property annotation

### DIFF
--- a/orchestrator/task.py
+++ b/orchestrator/task.py
@@ -66,6 +66,7 @@ class MakeDatasets(DockerTask):
     def requires(self):
         return DownloadData()
 
+    @property
     def command(self):
         # TODO: implement correct command
         # Try to get the input path from self.requires() ;)


### PR DESCRIPTION
MIssing property annotation causes an error when creating a container. Without the annotation the field is just a method and when the orchestrator utils code tries to JSON-serialize it, the task fails.

Stack trace:

```
orchestrator_1    | Traceback (most recent call last):
orchestrator_1    |   File "/usr/local/lib/python3.6/site-packages/luigi/worker.py", line 199, in run
orchestrator_1    |     new_deps = self._run_get_new_deps()
orchestrator_1    |   File "/usr/local/lib/python3.6/site-packages/luigi/worker.py", line 141, in _run_get_new_deps
orchestrator_1    |     task_gen = self.task.run()
orchestrator_1    |   File "/opt/orchestrator/util.py", line 353, in run
orchestrator_1    |     self._run_and_track_task()
orchestrator_1    |   File "/opt/orchestrator/util.py", line 365, in _run_and_track_task
orchestrator_1    |     self.configuration,
orchestrator_1    |   File "/opt/orchestrator/util.py", line 185, in run_container
orchestrator_1    |     **configuration)
orchestrator_1    |   File "/usr/local/lib/python3.6/site-packages/docker/models/containers.py", line 803, in run
orchestrator_1    |     detach=detach, **kwargs)
orchestrator_1    |   File "/usr/local/lib/python3.6/site-packages/docker/models/containers.py", line 861, in create
orchestrator_1    |     resp = self.client.api.create_container(**create_kwargs)
orchestrator_1    |   File "/usr/local/lib/python3.6/site-packages/docker/api/container.py", line 429, in create_container
orchestrator_1    |     return self.create_container_from_config(config, name)
orchestrator_1    |   File "/usr/local/lib/python3.6/site-packages/docker/api/container.py", line 439, in create_container_from_config
orchestrator_1    |     res = self._post_json(u, data=config, params=params)
orchestrator_1    |   File "/usr/local/lib/python3.6/site-packages/docker/api/client.py", line 289, in _post_json
orchestrator_1    |     return self._post(url, data=json.dumps(data2), **kwargs)
orchestrator_1    |   File "/usr/local/lib/python3.6/json/__init__.py", line 231, in dumps
orchestrator_1    |     return _default_encoder.encode(obj)
orchestrator_1    |   File "/usr/local/lib/python3.6/json/encoder.py", line 199, in encode
orchestrator_1    |     chunks = self.iterencode(o, _one_shot=True)
orchestrator_1    |   File "/usr/local/lib/python3.6/json/encoder.py", line 257, in iterencode
orchestrator_1    |     return _iterencode(o, 0)
orchestrator_1    |   File "/usr/local/lib/python3.6/json/encoder.py", line 180, in default
orchestrator_1    |     o.__class__.__name__)
orchestrator_1    | TypeError: Object of type 'method' is not JSON serializable
```